### PR TITLE
Fix double input visual issue

### DIFF
--- a/skin/overlay.css
+++ b/skin/overlay.css
@@ -101,6 +101,10 @@
   flex: 5 1;
 }
 
+#expression-search-textbox > .textbox-input {
+  width: 820px;
+}
+
 .titlebar-placeholder {
   flex: 0.1 100;
 }


### PR DESCRIPTION
This merely copy the commit from @wakely https://github.com/wakely/expression-search/commit/31618674b42097b4b8d554618dba399fd38e49ca

A note of caution: I'm no extension expert but dealing with this double input field issue by extending one of them pushing away the other (I suppose) looks like hiding dirt under the carpet. But hey, it works! So...